### PR TITLE
Specify the commit author

### DIFF
--- a/modules/repo/license.tf
+++ b/modules/repo/license.tf
@@ -1,4 +1,6 @@
 resource "github_repository_file" "license" {
+  commit_author       = var.commit_author
+  commit_email        = var.commit_email
   repository          = github_repository.this.name
   branch              = github_repository.this.default_branch
   file                = "LICENSE"

--- a/modules/repo/variables.tf
+++ b/modules/repo/variables.tf
@@ -1,3 +1,13 @@
+variable "commit_author" {
+  description = "The author name to use when committing files"
+  type        = string
+}
+
+variable "commit_email" {
+  description = "The email address to use when committing files"
+  type        = string
+}
+
 variable "license" {
   description = "The repository license"
   type        = string

--- a/modules/repo/workflows.tf
+++ b/modules/repo/workflows.tf
@@ -1,6 +1,8 @@
 resource "github_repository_file" "dot_github_workflows_ci_pr_size_yml" {
   count = var.has_ci ? 1 : 0
 
+  commit_author       = var.commit_author
+  commit_email        = var.commit_email
   repository          = github_repository.this.name
   branch              = github_repository.this.default_branch
   file                = ".github/workflows/ci-pr-size.yml"
@@ -12,6 +14,8 @@ resource "github_repository_file" "dot_github_workflows_ci_pr_size_yml" {
 resource "github_repository_file" "dot_github_workflows_ci_scheduled_yml" {
   count = var.has_ci ? 1 : 0
 
+  commit_author       = var.commit_author
+  commit_email        = var.commit_email
   repository          = github_repository.this.name
   branch              = github_repository.this.default_branch
   file                = ".github/workflows/ci-scheduled.yml"
@@ -23,6 +27,8 @@ resource "github_repository_file" "dot_github_workflows_ci_scheduled_yml" {
 resource "github_repository_file" "dot_github_workflows_ci_website_yml" {
   count = var.has_website && var.should_publish_website ? 1 : 0
 
+  commit_author       = var.commit_author
+  commit_email        = var.commit_email
   repository          = github_repository.this.name
   branch              = github_repository.this.default_branch
   file                = ".github/workflows/ci-website.yml"
@@ -34,6 +40,8 @@ resource "github_repository_file" "dot_github_workflows_ci_website_yml" {
 resource "github_repository_file" "dot_github_workflows_ci_yml" {
   count = var.has_ci ? 1 : 0
 
+  commit_author       = var.commit_author
+  commit_email        = var.commit_email
   repository          = github_repository.this.name
   branch              = github_repository.this.default_branch
   file                = ".github/workflows/ci.yml"
@@ -45,6 +53,8 @@ resource "github_repository_file" "dot_github_workflows_ci_yml" {
 resource "github_repository_file" "dot_github_workflows_publish_package_yml" {
   count = 1
 
+  commit_author       = var.commit_author
+  commit_email        = var.commit_email
   repository          = github_repository.this.name
   branch              = github_repository.this.default_branch
   file                = ".github/workflows/publish-package.yml"
@@ -56,6 +66,8 @@ resource "github_repository_file" "dot_github_workflows_publish_package_yml" {
 resource "github_repository_file" "dot_github_workflows_publish_release_yml" {
   count = 1
 
+  commit_author       = var.commit_author
+  commit_email        = var.commit_email
   repository          = github_repository.this.name
   branch              = github_repository.this.default_branch
   file                = ".github/workflows/publish-release.yml"
@@ -67,6 +79,8 @@ resource "github_repository_file" "dot_github_workflows_publish_release_yml" {
 resource "github_repository_file" "dot_github_workflows_publish_website_yml" {
   count = var.has_website && var.should_publish_website ? 1 : 0
 
+  commit_author       = var.commit_author
+  commit_email        = var.commit_email
   repository          = github_repository.this.name
   branch              = github_repository.this.default_branch
   file                = ".github/workflows/publish-website.yml"

--- a/repos-template.tf
+++ b/repos-template.tf
@@ -21,6 +21,8 @@ resource "github_repository" "template_repo" {
 }
 
 resource "github_repository_file" "template_repo_license" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.template_repo.name
   branch              = github_repository.template_repo.default_branch
   file                = "LICENSE"
@@ -30,6 +32,8 @@ resource "github_repository_file" "template_repo_license" {
 }
 
 resource "github_repository_file" "template_repo_dot_github_workflows_ci_pr_size_yml" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.template_repo.name
   branch              = github_repository.template_repo.default_branch
   file                = ".github/workflows/ci-pr-size.yml"
@@ -39,6 +43,8 @@ resource "github_repository_file" "template_repo_dot_github_workflows_ci_pr_size
 }
 
 resource "github_repository_file" "template_repo_dot_github_workflows_ci_scheduled_yml" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.template_repo.name
   branch              = github_repository.template_repo.default_branch
   file                = ".github/workflows/ci-scheduled.yml"
@@ -48,6 +54,8 @@ resource "github_repository_file" "template_repo_dot_github_workflows_ci_schedul
 }
 
 resource "github_repository_file" "template_repo_dot_github_workflows_ci_website_yml" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.template_repo.name
   branch              = github_repository.template_repo.default_branch
   file                = ".github/workflows/ci-website.yml"
@@ -57,6 +65,8 @@ resource "github_repository_file" "template_repo_dot_github_workflows_ci_website
 }
 
 resource "github_repository_file" "template_repo_dot_github_workflows_ci_yml" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.template_repo.name
   branch              = github_repository.template_repo.default_branch
   file                = ".github/workflows/ci.yml"
@@ -66,6 +76,8 @@ resource "github_repository_file" "template_repo_dot_github_workflows_ci_yml" {
 }
 
 resource "github_repository_file" "template_repo_dot_github_workflows_publish_package_yml" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.template_repo.name
   branch              = github_repository.template_repo.default_branch
   file                = ".github/workflows/publish-package.yml"
@@ -75,6 +87,8 @@ resource "github_repository_file" "template_repo_dot_github_workflows_publish_pa
 }
 
 resource "github_repository_file" "template_repo_dot_github_workflows_publish_release_yml" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.template_repo.name
   branch              = github_repository.template_repo.default_branch
   file                = ".github/workflows/publish-release.yml"
@@ -84,6 +98,8 @@ resource "github_repository_file" "template_repo_dot_github_workflows_publish_re
 }
 
 resource "github_repository_file" "template_repo_dot_github_workflows_publish_website_yml" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.template_repo.name
   branch              = github_repository.template_repo.default_branch
   file                = ".github/workflows/publish-website.yml"

--- a/repos-unique.tf
+++ b/repos-unique.tf
@@ -14,6 +14,8 @@ resource "github_repository" "dot_github" {
 }
 
 resource "github_repository_file" "dot_github_license" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.dot_github.name
   branch              = github_repository.dot_github.default_branch
   file                = "LICENSE"
@@ -50,6 +52,8 @@ resource "github_repository" "dot_github_dot_io" {
 }
 
 resource "github_repository_file" "dot_github_dot_io_license" {
+  commit_author       = local.commit_author
+  commit_email        = local.commit_email
   repository          = github_repository.dot_github_dot_io.name
   branch              = github_repository.dot_github_dot_io.default_branch
   file                = "LICENSE"

--- a/repos.tf
+++ b/repos.tf
@@ -1,64 +1,76 @@
 module "repo_branding" {
-  source      = "./modules/repo"
-  license     = local.license
-  template    = local.template
-  primary_url = local.primary_url
-  name        = "branding"
-  description = "Branding assets for Snout"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  template      = local.template
+  primary_url   = local.primary_url
+  name          = "branding"
+  description   = "Branding assets for Snout"
 
   has_ci = false
 }
 
 module "repo_docusaurus_config" {
-  source      = "./modules/repo"
-  license     = local.license
-  template    = local.template
-  primary_url = local.primary_url
-  name        = "docusaurus-config"
-  description = "The Docusaurus configuration used by Snout repositories"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  template      = local.template
+  primary_url   = local.primary_url
+  name          = "docusaurus-config"
+  description   = "The Docusaurus configuration used by Snout repositories"
 
   has_ci = false
 }
 
 module "repo_eslint_config" {
-  source      = "./modules/repo"
-  license     = local.license
-  primary_url = local.primary_url
-  name        = "eslint-config"
-  description = "The ESLint configuration used by Snout repositories"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  primary_url   = local.primary_url
+  name          = "eslint-config"
+  description   = "The ESLint configuration used by Snout repositories"
 
   has_ci = false
 }
 
 module "repo_eslint_config_react" {
-  source      = "./modules/repo"
-  license     = local.license
-  template    = local.template
-  primary_url = local.primary_url
-  name        = "eslint-config-react"
-  description = "The ESLint configuration used by Snout repositories that use React"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  template      = local.template
+  primary_url   = local.primary_url
+  name          = "eslint-config-react"
+  description   = "The ESLint configuration used by Snout repositories that use React"
 
   has_ci = false
 }
 
 module "repo_jest_config" {
-  source      = "./modules/repo"
-  license     = local.license
-  template    = local.template
-  primary_url = local.primary_url
-  name        = "jest-config"
-  description = "The Jest configuration used by Snout repositories"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  template      = local.template
+  primary_url   = local.primary_url
+  name          = "jest-config"
+  description   = "The Jest configuration used by Snout repositories"
 
   has_ci = false
 }
 
 module "repo_regexp" {
-  source      = "./modules/repo"
-  license     = local.license
-  template    = local.template
-  primary_url = local.primary_url
-  name        = "regexp"
-  description = "Utility functions for working with regular expressions"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  template      = local.template
+  primary_url   = local.primary_url
+  name          = "regexp"
+  description   = "Utility functions for working with regular expressions"
 
   topics = [
     "escape",
@@ -73,12 +85,14 @@ module "repo_regexp" {
 }
 
 module "repo_router_path" {
-  source      = "./modules/repo"
-  license     = local.license
-  template    = local.template
-  primary_url = local.primary_url
-  name        = "router-path"
-  description = "A simple, light-weight, type-safe router path implementation"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  template      = local.template
+  primary_url   = local.primary_url
+  name          = "router-path"
+  description   = "A simple, light-weight, type-safe router path implementation"
 
   topics = [
     "path",
@@ -91,12 +105,14 @@ module "repo_router_path" {
 }
 
 module "repo_router_path_extras" {
-  source      = "./modules/repo"
-  license     = local.license
-  template    = local.template
-  primary_url = local.primary_url
-  name        = "router-path-extras"
-  description = "Additional parameter types for Snout router path"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  template      = local.template
+  primary_url   = local.primary_url
+  name          = "router-path-extras"
+  description   = "Additional parameter types for Snout router path"
 
   topics = [
     "path",
@@ -110,12 +126,14 @@ module "repo_router_path_extras" {
 }
 
 module "repo_tsconfig" {
-  source      = "./modules/repo"
-  license     = local.license
-  template    = local.template
-  primary_url = local.primary_url
-  name        = "tsconfig"
-  description = "The TypeScript configuration used by Snout repositories"
+  source        = "./modules/repo"
+  commit_author = local.commit_author
+  commit_email  = local.commit_email
+  license       = local.license
+  template      = local.template
+  primary_url   = local.primary_url
+  name          = "tsconfig"
+  description   = "The TypeScript configuration used by Snout repositories"
 
   has_ci = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,7 @@
 locals {
   owner          = "snout-router"
+  commit_author  = "snout-router-repo-manager[bot]"
+  commit_email   = "97502368+snout-router-repo-manager[bot]@users.noreply.github.com"
   primary_domain = "snout.dev"
   primary_url    = "https://${local.primary_domain}"
   license        = file("LICENSE")


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/snout-router/.github/CONTRIBUTING.md.

Don't forget to include any relevant docs changes, if you feel comfortable doing so :)
-->

#### What change does this introduce?

Repository files will be committed with an explicit author name and email address.

#### Why make this change?

Without this, Terraform misrepresents the committer of files. For imported files, it will imitate the previous committer of the file. For newly created files with no previous committer, it will initially commit as the app it is authenticated as, then subsequent commits will appear to come from "GitHub". Neither of these outcomes are desirable.

#### Is there anything you are unsure about?

*N/A*

#### What issues does this relate to?

*N/A*
